### PR TITLE
[Fix] Making the banner size the size of the table

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,0 +1,25 @@
+from dynamictableprint import DynamicTablePrint
+import pandas as pd
+
+d = {
+    'names': [
+        "Albert Einstein",
+        "Issac Newton",
+        "Stephen Hawkings"
+    ],
+    'places': [
+        "Ulm, Germany",
+        "Wolsthorpe Manor, United Kingdom",
+        "Oxford, United Kingdom"
+    ],
+    'Foods': [
+        "Spaghetti",
+        "Pasta",
+        "Noodles"
+    ]
+}
+data_frame = pd.DataFrame(data=d)
+
+dtp = DynamicTablePrint(data_frame, angel_column='Foods', squish_column='places')
+dtp.config.banner = 'Things!'
+dtp.write_to_screen()


### PR DESCRIPTION
Looking at #4 we see that the size of the table and the size of the banner are not related at all. 
We fix this by providing an example where we follow the size of the table. If the size of the table is less than the available screen width, follow the size of the screen. 

