### PR TITLE
[Fix] Empty Table causing Issues

### DIFF
--- a/dynamictableprint/dynamicprinter.py
+++ b/dynamictableprint/dynamicprinter.py
@@ -80,6 +80,7 @@ class DynamicTablePrint:
                 self.config.empty_banner,
                 width=screen_width,
             )
+            return
 
         tp.dataframe(modified_data_frame, width=widths)
 
@@ -90,7 +91,7 @@ class DynamicTablePrint:
         Takes into acccount the columns and gaps between them
         """
         number_columns = len(columns)
-        screen_width_exc_side_bars = screen_width - 2 # bars
+        screen_width_exc_side_bars = screen_width - DefaultConfig().edge_width
         screen_width_inc_columns = \
             screen_width_exc_side_bars - 3 * (number_columns - 1)
         return screen_width_inc_columns
@@ -105,7 +106,7 @@ class DynamicTablePrint:
         """
         number_columns = len(column_widths.values())
         table_width = sum(column_widths.values())
-        table_width = table_width + 2 # bars
+        table_width = table_width + DefaultConfig().edge_width
         table_width = table_width + 3 * (number_columns - 1)
         return int(table_width)
 
@@ -120,6 +121,11 @@ class DynamicTablePrint:
         We take the full length of the available screen
         and force the widths to be less than or equal to this
         """
+        if self.data_frame.empty:
+            return (self.config.default_screen_width,
+                    self.config.default_screen_width - self.config.edge_width,
+                    self.data_frame)
+
         column_widths, columns = self._column_widths(self.data_frame)
 
         printable_screen_width = self.printable_screen_width(
@@ -154,8 +160,8 @@ class DefaultConfig:
     __slots__ = [
         "banner",
         "empty_banner",
-        "item_padding",
         "default_screen_width",
+        "edge_width",
     ]
 
     def __init__(self):
@@ -167,5 +173,5 @@ class DefaultConfig:
         """ Banner when there is no content """
         self.empty_banner = 'Error: No results'
 
-        """ Difference between the total item width and the screen width """
-        self.item_padding = 8
+        """ Width due to spaces on either side of the table"""
+        self.edge_width = 2

--- a/dynamictableprint/squisher.py
+++ b/dynamictableprint/squisher.py
@@ -136,10 +136,31 @@ class SquishCalculator:
         """
         self.__max_squish_ratio = new_ratio
 
+    @staticmethod
+    def _is_blank(measurement):
+        if measurement is None:
+            return False
+
+        return True
+
+    def is_blank(self, measurements):
+        """
+        Returns true if all values in the measurements iterator
+        are empty
+        """
+        filtered = filter(self._is_blank, measurements)
+        if not filtered:
+            return True
+
+        return False
+
     def squish_columns(self):
         """
         Squishes the columns to fit within the allocated_width
         """
+        if self.is_blank(self.column_measurements):
+            return self.column_measurements
+
         for column in self._squish_order():
 
             if self._within_allocated_width():

--- a/tests/test_dynamicprinter.py
+++ b/tests/test_dynamicprinter.py
@@ -26,10 +26,20 @@ class TestDynamicTablePrint(unittest.TestCase):
             'squished': ["SQUISHABLE"*4 for i in range(length)],
             'saved': ["CANADA"*3 for i in range(length)],
         }
-        self.dataframe = pd.DataFrame(
+        self.dataframe = pd.DataFrame.from_dict(
             raw_data,
-            columns=[*raw_data],
         )
+
+        self.blank_dataframe = pd.DataFrame.from_dict(
+            {
+                'stupid': [],
+                'idiot': [],
+                'how could I forget': [],
+                'that blank': [],
+                'was a think': [],
+            }
+        )
+
         self.auco = DynamicTablePrint(
             self.dataframe,
             angel_column='saved',
@@ -67,6 +77,16 @@ class TestDynamicTablePrint(unittest.TestCase):
         assert DynamicTablePrint.printable_screen_width(
             ['something_good', 'something_bad', 'squished', 'saved'],
             default_screen_width) == printable_width
+
+    def test_empty_dataframe(self):
+        """
+        if printing an empty dataframe, nothing should happen
+        """
+        dtp = DynamicTablePrint(self.blank_dataframe)
+        dtp.config.empty_banner = 'Test in Progress'
+        dtp.squish_calculator = mock.MagicMock()
+        dtp.write_to_screen()
+        dtp.squish_calculator.assert_not_called()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If a table is empty, an error occurs when we try to calculate the length of objects which have no length themselves. I've added the following fix:

```py
 if self.data_frame.empty:
    return (self.config.default_screen_width,
        self.config.default_screen_width - self.config.edge_width,
        self.data_frame)
```
The `self.config.edge_width` introduced merely ensures that we take into account the maximum size of the table subtracted from the width of the side columns. 